### PR TITLE
Issue32 카테고리 페이지 컴포넌트 구현

### DIFF
--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -3,12 +3,10 @@ import styled from "styled-components";
 import CategoryItem from "./CategoryItem";
 
 interface CategoryProps {
-  categories: [
-    {
-      categoryId: number;
-      desc: string;
-    }
-  ];
+  categories: {
+    categoryId: number;
+    desc: string;
+  }[];
 }
 
 const CategoryContainer = styled.ul`

--- a/src/components/CategoryPage.tsx
+++ b/src/components/CategoryPage.tsx
@@ -13,7 +13,7 @@ const CategoryPageConatainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 1em;
+  gap: 1.5em;
 `;
 
 const categories = [
@@ -60,10 +60,14 @@ const stores: StoreListProps["stores"] = [
 function CategoryPage() {
   return (
     <CategoryPageConatainer>
-      <SectionHeader>카테고리</SectionHeader>
-      <Category categories={categories} />
-      <SectionHeader>이런 메뉴는 어떤가요?</SectionHeader>
-      <StoreList stores={stores} />
+      <section>
+        <SectionHeader>카테고리</SectionHeader>
+        <Category categories={categories} />
+      </section>
+      <section>
+        <SectionHeader>이런 메뉴는 어떤가요?</SectionHeader>
+        <StoreList stores={stores} />
+      </section>
     </CategoryPageConatainer>
   );
 }

--- a/src/components/CategoryPage.tsx
+++ b/src/components/CategoryPage.tsx
@@ -1,0 +1,71 @@
+import styled from "styled-components";
+
+import type { StoreListProps } from "./StoreList";
+
+import Category from "./Category";
+import SectionHeader from "./SectionHeader";
+import StoreList from "./StoreList";
+
+const CategoryPageConatainer = styled.div`
+  width: 375px; // TODO: 각 페이지 컴포넌트마다 width를 설정하는 게 아니라,  main tag를 App.tsx에 넣고 width를 지정해야 할 듯!
+  padding: 1em;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1em;
+`;
+
+const categories = [
+  { categoryId: 1, desc: "한식" },
+  { categoryId: 2, desc: "중식" },
+  { categoryId: 3, desc: "일식" },
+  { categoryId: 4, desc: "양식" },
+  { categoryId: 5, desc: "디저트" },
+  { categoryId: 6, desc: "야식" },
+  { categoryId: 7, desc: "패스트푸드" },
+  { categoryId: 8, desc: "기타" },
+];
+
+const stores: StoreListProps["stores"] = [
+  {
+    storeId: 1,
+    thumbnailUrl:
+      "https://images.unsplash.com/photo-1626645738196-c2a7c87a8f58?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+    name: "냠냠 치킨",
+    campus: "잠실",
+    distance: 0.5,
+    starCount: 3,
+  },
+  {
+    storeId: 2,
+    thumbnailUrl:
+      "https://images.unsplash.com/photo-1626645738196-c2a7c87a8f58?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+    name: "욤욤 치킨",
+    campus: "잠실",
+    distance: 0.2,
+    starCount: 4,
+  },
+  {
+    storeId: 3,
+    thumbnailUrl:
+      "https://images.unsplash.com/photo-1626645738196-c2a7c87a8f58?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80",
+    name: "념념 치킨",
+    campus: "잠실",
+    distance: 1,
+    starCount: 1,
+  },
+];
+
+function CategoryPage() {
+  return (
+    <CategoryPageConatainer>
+      <SectionHeader>카테고리</SectionHeader>
+      <Category categories={categories} />
+      <SectionHeader>이런 메뉴는 어떤가요?</SectionHeader>
+      <StoreList stores={stores} />
+    </CategoryPageConatainer>
+  );
+}
+
+export default CategoryPage;

--- a/src/components/StoreList.tsx
+++ b/src/components/StoreList.tsx
@@ -4,7 +4,7 @@ import type { StoreListItemProps } from "./StoreListItem";
 
 import StoreListItem from "./StoreListItem";
 
-interface StoreListProps {
+export interface StoreListProps {
   stores: (StoreListItemProps & { storeId: number })[];
 }
 

--- a/src/stories/CategoryPage.stories.jsx
+++ b/src/stories/CategoryPage.stories.jsx
@@ -1,0 +1,10 @@
+import CategoryPage from "../components/CategoryPage";
+
+export default {
+  title: "Component/CategoryPage",
+  component: CategoryPage,
+};
+
+const Template = (args) => <CategoryPage {...args} />;
+
+export const Default = Template.bind({});


### PR DESCRIPTION
#32 카테고리 페이지 컴포넌트 구현

# 논의 할 것
- App.tsx나 어딘가에 main 태그를 만들어서 width 설정하고 페이지 컴포넌트들은 그 내부 내용만 갈아치우는 건 어떨까요?
   예시:
   ```js
   <main> // width: 375px, display: flex, flex-direction: column, ...
      {/* 라우팅 관련 ...*/}
      <CategoryPage/>
      ...
   </main> 
   // 각 페이지 컴포넌트 내부에서는 <></>로 감싸든 div로 감싸든 암튼
   ```
- 스타일 단위도 통일해야 할 듯!! px, em, rem