### PR TITLE
Issue16 캠퍼스 선택 페이지 레이아웃 및 버튼 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,19 +2,29 @@ import PageLayout from "./components/layout/PageLayout/PageLayout";
 import CategoryDetailPage from "./components/pages/CategoryDetailPage";
 import CategoryPage from "./components/pages/CategoryPage";
 import StoreDetailPage from "./components/pages/StoreDetailPage";
+import { campusContext } from "context/CampusContextProvider";
+import { useContext } from "react";
 import { Route, Routes } from "react-router-dom";
 
+import CampusSelectPage from "components/pages/CampusSelectPage/CampusSelectPage";
+
 function App() {
+  const campus = useContext(campusContext);
+
   return (
     <Routes>
-      <Route element={<PageLayout />}>
-        <Route path="/" element={<CategoryPage />} />
-        <Route
-          path="/category"
-          element={<CategoryDetailPage categoryName="임시" />}
-        />
-        <Route path="/store-detail" element={<StoreDetailPage />} />
-      </Route>
+      {campus === null ? (
+        <Route path="*" element={<CampusSelectPage />} />
+      ) : (
+        <Route element={<PageLayout />}>
+          <Route path="/" element={<CategoryPage />} />
+          <Route
+            path="/category"
+            element={<CategoryDetailPage categoryName="임시" />}
+          />
+          <Route path="/store-detail" element={<StoreDetailPage />} />
+        </Route>
+      )}
     </Routes>
   );
 }

--- a/src/components/layout/Header/Header.style.tsx
+++ b/src/components/layout/Header/Header.style.tsx
@@ -25,6 +25,11 @@ export const PageName = styled.h1`
   font-size: 1.25rem;
 `;
 
+export const Campus = styled.span`
+  font-size: 0.8rem;
+  color: ${({ theme }) => theme.black};
+`;
+
 export const RightWrapper = styled.div`
   display: flex;
   align-items: flex-end;

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,4 +1,5 @@
-import { useReducer } from "react";
+import { campusContext } from "context/CampusContextProvider";
+import { useContext, useReducer } from "react";
 import { BsSearch } from "react-icons/bs";
 import { MdCancel } from "react-icons/md";
 
@@ -15,6 +16,8 @@ function Header() {
   );
   const [isLogin] = useLogin();
 
+  const campus = useContext(campusContext);
+
   const handleSearchOpen = () => {
     setSearchOpen();
   };
@@ -30,7 +33,9 @@ function Header() {
         </>
       ) : (
         <>
-          <S.PageName>mat.zip</S.PageName>
+          <S.PageName>
+            MAT.ZIP{campus && <S.Campus> :{campus}</S.Campus>}
+          </S.PageName>
           <S.RightWrapper>
             <S.SearchToggleButton onClick={handleSearchOpen}>
               <BsSearch />

--- a/src/components/pages/CampusSelectPage/CampusSelectPage.style.tsx
+++ b/src/components/pages/CampusSelectPage/CampusSelectPage.style.tsx
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+
+export const MainContainer = styled.main`
+  width: 23.45rem;
+  height: 100vh;
+  margin: 0 auto;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 3.125rem;
+
+  background-color: ${({ theme }) => theme.white};
+`;
+
+export const Title = styled.h1``;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 1.25rem;
+`;
+
+export const Button = styled.button`
+  width: 8rem;
+  height: 8rem;
+
+  color: ${({ theme }) => theme.white};
+  font-size: 32px;
+  font-weight: 700;
+
+  border: none;
+  border-radius: 1.25rem;
+
+  background-color: ${({ theme }) => theme.primary};
+  box-shadow: 0.065rem 0.065rem 0.065rem ${({ theme }) => theme.secondary};
+`;

--- a/src/components/pages/CampusSelectPage/CampusSelectPage.tsx
+++ b/src/components/pages/CampusSelectPage/CampusSelectPage.tsx
@@ -1,14 +1,17 @@
 import { Campus, setCampusContext } from "context/CampusContextProvider";
 import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
 
 import * as S from "components/pages/CampusSelectPage/CampusSelectPage.style";
 
 function CampusSelectPage() {
   const setCampus = useContext(setCampusContext);
+  const navigate = useNavigate();
 
   const handleCampusSelect: (campus: Campus) => React.MouseEventHandler =
     (campus: Campus) => () => {
       setCampus(campus);
+      navigate("/");
     };
 
   return (

--- a/src/components/pages/CampusSelectPage/CampusSelectPage.tsx
+++ b/src/components/pages/CampusSelectPage/CampusSelectPage.tsx
@@ -1,0 +1,25 @@
+import { Campus, setCampusContext } from "context/CampusContextProvider";
+import { useContext } from "react";
+
+import * as S from "components/pages/CampusSelectPage/CampusSelectPage.style";
+
+function CampusSelectPage() {
+  const setCampus = useContext(setCampusContext);
+
+  const handleCampusSelect: (campus: Campus) => React.MouseEventHandler =
+    (campus: Campus) => () => {
+      setCampus(campus);
+    };
+
+  return (
+    <S.MainContainer>
+      <S.Title>캠퍼스를 선택해주세요</S.Title>
+      <S.ButtonWrapper>
+        <S.Button onClick={handleCampusSelect("잠실")}>잠실</S.Button>
+        <S.Button onClick={handleCampusSelect("선릉")}>선릉</S.Button>
+      </S.ButtonWrapper>
+    </S.MainContainer>
+  );
+}
+
+export default CampusSelectPage;

--- a/src/context/CampusContextProvider.tsx
+++ b/src/context/CampusContextProvider.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+
+type Campus = "잠실" | "선릉";
+type CampusContext = Campus | null;
+
+type SetCampusContext = React.Dispatch<React.SetStateAction<CampusContext>>;
+
+export const campusContext = React.createContext<null | CampusContext>(null);
+export const setCampusContext =
+  React.createContext<null | SetCampusContext>(null);
+
+function CampusContextProvider({ children }: React.PropsWithChildren<{}>) {
+  const [campus, setCampus] = useState<CampusContext>(null);
+
+  return (
+    <campusContext.Provider value={campus}>
+      <setCampusContext.Provider value={setCampus}>
+        {children}
+      </setCampusContext.Provider>
+    </campusContext.Provider>
+  );
+}
+
+export default CampusContextProvider;

--- a/src/context/CampusContextProvider.tsx
+++ b/src/context/CampusContextProvider.tsx
@@ -1,17 +1,17 @@
-import React, { useState } from "react";
+import React from "react";
+
+import useStoredState from "hooks/useStoredState";
 
 export type Campus = "잠실" | "선릉";
 type CampusContext = Campus | null;
 
-type SetCampusContext = React.Dispatch<
-  React.SetStateAction<CampusContext | null>
->;
+type SetCampusContext = (value: CampusContext) => void;
 
 export const campusContext = React.createContext<null | CampusContext>(null);
 export const setCampusContext = React.createContext<SetCampusContext>(() => {});
 
 function CampusContextProvider({ children }: React.PropsWithChildren<{}>) {
-  const [campus, setCampus] = useState<CampusContext>(null);
+  const [campus, setCampus] = useStoredState<CampusContext>("campus", null);
 
   return (
     <campusContext.Provider value={campus}>

--- a/src/context/CampusContextProvider.tsx
+++ b/src/context/CampusContextProvider.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from "react";
 
-type Campus = "잠실" | "선릉";
+export type Campus = "잠실" | "선릉";
 type CampusContext = Campus | null;
 
-type SetCampusContext = React.Dispatch<React.SetStateAction<CampusContext>>;
+type SetCampusContext = React.Dispatch<
+  React.SetStateAction<CampusContext | null>
+>;
 
 export const campusContext = React.createContext<null | CampusContext>(null);
-export const setCampusContext =
-  React.createContext<null | SetCampusContext>(null);
+export const setCampusContext = React.createContext<SetCampusContext>(() => {});
 
 function CampusContextProvider({ children }: React.PropsWithChildren<{}>) {
   const [campus, setCampus] = useState<CampusContext>(null);

--- a/src/hooks/useStoredState.tsx
+++ b/src/hooks/useStoredState.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useMemo, useState } from "react";
+
+type ReturnValues<T> = [T, (value: T) => void];
+
+function useStoredState<T>(key: string, initialValue: T): ReturnValues<T> {
+  const savedData = useMemo(
+    () => JSON.parse(window.localStorage.getItem(key) as string),
+    []
+  );
+  const [data, _setData] = useState<T>(savedData || initialValue);
+
+  const setData = (value: T) => {
+    _setData(value);
+    window.localStorage.setItem(key, JSON.stringify(value));
+  };
+
+  return [data, setData];
+}
+
+export default useStoredState;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import CampusContextProvider from "context/CampusContextProvider";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -21,9 +22,11 @@ root.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <CampusContextProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </CampusContextProvider>
     </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
캠퍼스 선택 페이지 구현

1. 캠퍼스 전역 상태를 context api로 구현
2. `provider` 컴포넌트를 만들어서 `data`, `setdata`를 구분해서 `context`로 제공
3. `campus`가 `null`인 경우 자동으로 선택 페이지로 이동
4. 잠실/선릉 캠퍼스 선택하면 홈 페이지로 리다이렉션
5. 선택 정보는 `localStorage`에 저장 => 왠만하면 한 번 선택한 캠퍼스를 변경할 일이 없을 것이라고 판단
6. 캠퍼스가 선택되면 상단 메뉴 바 로고 옆에 선택한 캠퍼스 표시
7. 전역에서 `context`에 접근해서 `campus` 정보 사용 가능

TODO
캠퍼스 변경할 수 있는 버튼을 제공할 자리 찾아서 클릭 시 `campus`를 `null`로 설정하기