### PR TITLE
SonarCloud code analysis 추가

### DIFF
--- a/.github/workflows/sonar-cloud-analysis-build.yml
+++ b/.github/workflows/sonar-cloud-analysis-build.yml
@@ -1,0 +1,19 @@
+name:  Sonar Cloud Analysis Build
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar-cloud-analysis-build.yml
+++ b/.github/workflows/sonar-cloud-analysis-build.yml
@@ -1,7 +1,7 @@
 name:  Sonar Cloud Analysis Build
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=The-Fellowship-of-the-matzip_mat.zip-front
+sonar.organization=the-fellowship-of-the-matzip
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=mat.zip-front
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
프론트 레포지토리 내에서 코드에 대한 정적 분석 도구 추가

- 현재 `develop`을 향한 pr작성 시 해당 action이 동작하여 analysis 동작
- 차후 필요 시 sonar cloud analysis 가 통과한 경우에만 merge할 수 있도록 respository 조건 추가 가능