### PR TITLE
Issue113 메뉴에서 캠퍼스 전환 방식으로 초기화가 아니라 토글로 변경

### DIFF
--- a/src/components/layout/MenuDrawer/MenuDrawer.tsx
+++ b/src/components/layout/MenuDrawer/MenuDrawer.tsx
@@ -2,6 +2,8 @@ import { useContext } from "react";
 import ReactDOM from "react-dom";
 
 import { AUTH_LINK } from "constants/api";
+import { getOtherCampus } from "constants/campus";
+import type { Campus } from "constants/campus";
 import MESSAGES from "constants/messages";
 
 import { campusContext, setCampusContext } from "context/CampusContextProvider";
@@ -14,15 +16,21 @@ type Props = { closeMenu: () => void; isLoggedIn: boolean };
 
 function MenuDrawer({ closeMenu, isLoggedIn }: Props) {
   const campus = useContext(campusContext);
+  const otherCampus = getOtherCampus(campus as Campus);
   const setCampus = useContext(setCampusContext);
 
   const { logout } = useLogin();
 
   const handleCampusChangeRequest = () => {
-    if (!window.confirm(MESSAGES.CAMPUS_CHANGE_CONFIRM(campus as string))) {
+    if (
+      !window.confirm(
+        MESSAGES.CAMPUS_CHANGE_CONFIRM(campus as Campus, otherCampus)
+      )
+    ) {
       return;
     }
-    setCampus(null);
+    setCampus(otherCampus);
+    closeMenu();
   };
 
   const handleLogout = () => {

--- a/src/constants/campus.tsx
+++ b/src/constants/campus.tsx
@@ -8,4 +8,8 @@ const CAMPUS = {
 export const getCampusId = (campusName: Campus) =>
   campusName === CAMPUS.JAMSIL.name ? CAMPUS.JAMSIL.id : CAMPUS.SEOULLEUNG.id;
 
+export const getOtherCampus = (currentCampus: Campus) =>
+  currentCampus === CAMPUS.JAMSIL.name
+    ? CAMPUS.SEOULLEUNG.name
+    : CAMPUS.JAMSIL.name;
 export default CAMPUS;

--- a/src/constants/messages.tsx
+++ b/src/constants/messages.tsx
@@ -1,5 +1,7 @@
 import { INPUT_MAX_LENGTH } from "./rules";
 
+import type { Campus } from "constants/campus";
+
 const MESSAGES = {
   LOGIN_REQUIRED: "로그인 후 사용해주세요",
   LOGIN_FAIL: "로그인에 실패했습니다. 다시 시도해주세요.",
@@ -7,8 +9,8 @@ const MESSAGES = {
   LOGOUT_CONFIRM: "로그아웃 하시겠습니까?",
   LOGOUT_COMPLETE: "로그아웃 하였습니다.",
 
-  CAMPUS_CHANGE_CONFIRM: (currentCampus: string) =>
-    `현재 선택된 캠퍼스는 ${currentCampus}입니다 캠퍼스를 변경하시겠습니까?`,
+  CAMPUS_CHANGE_CONFIRM: (currentCampus: Campus, otherCampus: Campus) =>
+    `현재 선택된 캠퍼스는 ${currentCampus}입니다. ${otherCampus} 캠퍼스로 변경하시겠습니까?`,
   CATEGORY_FIND_FAILED: "카테고리 이름을 불러오지 못했습니다.",
 
   EXCEED_MENU_MAX_LENGTH: `메뉴 이름은 ${INPUT_MAX_LENGTH.MENU}자 이내로 입력해주세요.`,


### PR DESCRIPTION
# 기존
- 캠퍼스 변경 버튼을 누르면 확인 메시지 후 캠퍼스 초기화, 선택 페이지로 이동

# 변경
- 현재는 캠퍼스가 두 개로만 구성되어있으므로 자동으로 다른 캠퍼스로 설정되도록 수정
- 메시지도 그에 맞게 수정

closed #113 