### PR TITLE
Issue117 식당 상세에서 카카오 맵으로 열기 했을 때 새 탭에서 열리도록 변경

### DIFF
--- a/src/components/pages/StoreDetailPage/StoreDetailTitle/StoreDetailTitle.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailTitle/StoreDetailTitle.tsx
@@ -37,7 +37,9 @@ function StoreDetailTitle({
         <p>
           {campus} 캠퍼스 기준 도보 {distance}분
         </p>
-        <S.KakaoLink href={kakaoMapUrl}>카카오 맵으로 열기</S.KakaoLink>
+        <S.KakaoLink href={kakaoMapUrl} target="_blank">
+          카카오 맵으로 열기
+        </S.KakaoLink>
       </S.DescriptionWrapper>
     </S.TitleContainer>
   );


### PR DESCRIPTION
# 기존
카카오맵에서 열기 클릭 시 현재 페이지가 이동됨
# 변경
새 탭에서 열리도록 변경