### PR TITLE
campus 컨텍스트가 변경될 때 랜덤 추천 항목이 refetch 되도록 수정

### DIFF
--- a/src/components/pages/CategoryPage/CategoryPage.tsx
+++ b/src/components/pages/CategoryPage/CategoryPage.tsx
@@ -1,4 +1,5 @@
-import { useContext } from "react";
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useContext, useEffect } from "react";
 import { useQuery } from "react-query";
 
 import { NETWORK, SIZE } from "constants/api";
@@ -21,13 +22,17 @@ function CategoryPage() {
   const campusName = useContext(campusContext);
   const campusId = getCampusId(campusName as Campus);
 
-  const { data, isLoading, isError, error } = useQuery(
+  const { data, isLoading, isError, error, refetch } = useQuery(
     "randomStore",
     () => fetchRandomStoreList(campusId, SIZE.RANDOM_ITEM),
     {
       retry: NETWORK.RETRY_COUNT,
     }
   );
+
+  useEffect(() => {
+    refetch();
+  }, [campusName]);
 
   return (
     <S.CategoryPageContainer>


### PR DESCRIPTION
# 기존
campus 컨텍스트가 변해도 랜덤 추천 항목이 refetch 되지 않음 (모바일에서만 확인 가능 - 브라우저에서는 focus로 인한 refetch 작동)

# 변경
환경에 상관 없이 refetch (+ focus일 때 refetch를 끄면 어차피 필요할 듯)

# 질문
원래 react query에서는 fetcher 함수에 param이 변해도 refetch가 자동으로 되는게 아닌가요? 수동으로 해주는게 맞나요?