### PR TITLE
Issue126 Menu Drawer을 열고 스크롤 할 수 있는 현상을 수정

### DIFF
--- a/src/components/layout/MenuDrawer/MenuDrawer.style.tsx
+++ b/src/components/layout/MenuDrawer/MenuDrawer.style.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 export const Container = styled.div`
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
 

--- a/src/components/layout/MenuDrawer/MenuDrawer.tsx
+++ b/src/components/layout/MenuDrawer/MenuDrawer.tsx
@@ -52,6 +52,14 @@ function MenuDrawer({ closeMenu, isLoggedIn }: Props) {
     closeMenu();
   }, [location.key]);
 
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, []);
+
   return ReactDOM.createPortal(
     <S.Container>
       <S.Backdrop onClick={closeMenu} />


### PR DESCRIPTION
# 기존
Menu Drawer을 열고 스크롤 할 수 있는데 Menu Drawer는 absolute이라서 깨짐

# 변경
- Menu Drawer 생성은 position fixed로 수정
- 마운트 시 body의 스크롤 고정으로 변경