### PR TITLE
random pick 컴포넌트를 reducer로 리팩토링

### DIFF
--- a/src/components/pages/CategoryPage/RandomPick/reducer.ts
+++ b/src/components/pages/CategoryPage/RandomPick/reducer.ts
@@ -1,0 +1,69 @@
+import type { Store } from "mock/data";
+
+export const ACTION_TYPES = {
+  SET_BOARD: "SET_BOARD",
+  SPIN: "SPIN",
+  SHOW_RESULT: "SHOW_RESULT",
+  RESET: "RESET",
+} as const;
+
+type State = {
+  triggerAnimation: boolean;
+  rouletteBoard: string[];
+  pickedIndex: number | null;
+  result: Store | undefined;
+  isResultOpen: boolean;
+};
+
+type Action =
+  | {
+      type: typeof ACTION_TYPES.SET_BOARD;
+      payload: Pick<State, "rouletteBoard">;
+    }
+  | {
+      type: typeof ACTION_TYPES.SPIN;
+      payload: Pick<State, "pickedIndex" | "result" | "rouletteBoard">;
+    }
+  | {
+      type: typeof ACTION_TYPES.SHOW_RESULT;
+    }
+  | {
+      type: typeof ACTION_TYPES.RESET;
+      payload: Pick<State, "rouletteBoard">;
+    };
+
+export const initialState: State = {
+  triggerAnimation: false,
+  rouletteBoard: [],
+  pickedIndex: null,
+  result: undefined,
+  isResultOpen: false,
+};
+
+export const reducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case ACTION_TYPES.SET_BOARD: {
+      return { ...state, rouletteBoard: action.payload.rouletteBoard };
+    }
+    case ACTION_TYPES.SPIN: {
+      const { pickedIndex, result, rouletteBoard } = action.payload;
+
+      return {
+        ...state,
+        pickedIndex,
+        result,
+        rouletteBoard,
+        triggerAnimation: true,
+      };
+    }
+    case ACTION_TYPES.SHOW_RESULT: {
+      return { ...state, isResultOpen: true };
+    }
+    case ACTION_TYPES.RESET: {
+      return { ...initialState, rouletteBoard: action.payload.rouletteBoard };
+    }
+
+    default:
+      return initialState;
+  }
+};

--- a/src/hooks/useRandomPick.tsx
+++ b/src/hooks/useRandomPick.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useMemo, useReducer } from "react";
+import { createArray, getRandomNumber } from "util/randomUtils";
+
+import {
+  ACTION_TYPES,
+  initialState,
+  reducer,
+} from "components/pages/CategoryPage/RandomPick/reducer";
+
+import { Store } from "mock/data";
+
+function useRandomPick(stores: Store[]) {
+  const storeNamesArray = stores?.map((store) => store.name) || [];
+
+  const rouletteBaseArray = useMemo(
+    () => (stores !== undefined ? createArray(storeNamesArray, 20) : null),
+    [stores]
+  );
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const setRoulette = () => {
+    const rouletteBaseArray = createArray(storeNamesArray, 20);
+    dispatch({
+      type: ACTION_TYPES.SET_BOARD,
+      payload: { rouletteBoard: rouletteBaseArray || [] },
+    });
+  };
+
+  const startSpin = (stores: Store[], randomNumber: number) => {
+    if (stores === undefined) return;
+    dispatch({
+      type: ACTION_TYPES.SPIN,
+      payload: {
+        pickedIndex: randomNumber,
+        result: stores[randomNumber],
+        rouletteBoard: state.rouletteBoard.concat(
+          storeNamesArray.slice(0, randomNumber + 1)
+        ),
+      },
+    });
+  };
+
+  const openResult = () => {
+    dispatch({
+      type: ACTION_TYPES.SHOW_RESULT,
+    });
+  };
+
+  const reset = () => {
+    dispatch({
+      type: ACTION_TYPES.RESET,
+      payload: { rouletteBoard: rouletteBaseArray || [] },
+    });
+  };
+
+  const handleRunClick = () => {
+    if (state.result !== undefined) return;
+    const randomIndex = getRandomNumber(storeNamesArray.length);
+    startSpin(stores, randomIndex);
+  };
+
+  useEffect(() => {
+    setRoulette();
+  }, [stores]);
+
+  return { state, handleRunClick, openResult, reset };
+}
+
+export default useRandomPick;

--- a/src/util/randomUtils.ts
+++ b/src/util/randomUtils.ts
@@ -1,0 +1,7 @@
+export const getRandomNumber = (max: number) =>
+  Math.floor(Math.random() * (max - 1));
+
+export const createArray = <T>(arr: T[], n: number) => {
+  const repeat = Array<T[]>(n).fill(arr).flat();
+  return repeat;
+};


### PR DESCRIPTION
closes #142
Random Picker 컴포넌트의 복잡한 상태를 Reducer로 리팩토링한다
현재 상태가 총 5개이며, 초기 상태와 룰렛을 돌리고 결과를 표시하는 때의 상태로 다양하게 구성되어있음.
이를 리팩토링 차원에서 useReducer 훅으로 개선
이 로직을 다시 한 번 커스텀 훅으로 분리