### PR TITLE
Issue157 Modal, BottomSheet 열었을 때 디자인 수정

### DIFF
--- a/src/components/common/BottomSheet/BottomSheet.style.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.style.tsx
@@ -11,7 +11,7 @@ export const Container = styled.section<{ scrollOffset: number }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 100;
+  z-index: ${({ theme }) => theme.zIndex.overlay};
 `;
 
 export const Backdrop = styled.div`

--- a/src/components/common/BottomSheet/BottomSheet.style.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.style.tsx
@@ -11,6 +11,7 @@ export const Container = styled.section<{ scrollOffset: number }>`
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 100;
 `;
 
 export const Backdrop = styled.div`

--- a/src/components/common/Modal/Modal.style.tsx
+++ b/src/components/common/Modal/Modal.style.tsx
@@ -9,6 +9,7 @@ export const Container = styled.section<{ scrollOffset: number }>`
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: ${({ theme }) => theme.zIndex.overlay};
 `;
 
 export const Backdrop = styled.div`
@@ -36,7 +37,6 @@ export const Content = styled.div`
 
   border-radius: ${({ theme }) => theme.borderRadius.medium};
   box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.15);
-  z-index: 2;
 `;
 
 export const CloseButton = styled.button`

--- a/src/components/layout/Header/Header.style.tsx
+++ b/src/components/layout/Header/Header.style.tsx
@@ -22,7 +22,7 @@ export const Container = styled.header`
 
   background-color: ${({ theme }) => theme.color.primary};
 
-  z-index: 99;
+  z-index: ${({ theme }) => theme.zIndex.header};
 `;
 
 export const TopWrapper = styled.div`

--- a/src/components/layout/MenuDrawer/MenuDrawer.style.tsx
+++ b/src/components/layout/MenuDrawer/MenuDrawer.style.tsx
@@ -11,7 +11,7 @@ export const Container = styled.div`
   height: 100vh;
   margin: 0 auto;
 
-  z-index: 100;
+  z-index: ${({ theme }) => theme.zIndex.overlay};
 `;
 
 export const Backdrop = styled.div`

--- a/src/components/pages/StoreDetailPage/StoreDetailPage.style.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailPage.style.tsx
@@ -49,7 +49,7 @@ export const reviewButtonStyle = css`
   height: 4.8rem;
 
   border-radius: 50%;
-  z-index: 101;
+  z-index: ${({ theme }) => theme.zIndex.overlay};
 
   & > svg {
     & path {

--- a/src/style/Theme.ts
+++ b/src/style/Theme.ts
@@ -39,8 +39,14 @@ const borderRadius = {
   medium: "8px",
 };
 
+const zIndex = {
+  header: 2,
+  overlay: 3,
+};
+
 export const theme = {
   color,
   spacer,
   borderRadius,
+  zIndex,
 };


### PR DESCRIPTION
Issue #157 

- Modal, BottomSheet를 열었을 때 backdrop이 Header 위에 위치한다

<img width="393" alt="Screenshot 2023-06-19 at 6 04 07 PM" src="https://github.com/The-Fellowship-of-the-matzip/mat.zip-front/assets/51967731/9f144a22-a9b2-46f4-93cb-520e7c4079cc">
<img width="393" alt="Screenshot 2023-06-19 at 6 03 06 PM" src="https://github.com/The-Fellowship-of-the-matzip/mat.zip-front/assets/51967731/d8590784-c0ee-4682-9b47-779735f68c8b">
