### PR TITLE
Hotfix: v2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mat.zip",
-  "version": "1.2.0",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mat.zip",
-      "version": "1.2.0",
+      "version": "2.0.4",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mat.zip",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "homepage": "https://matzip.today",
   "dependencies": {

--- a/src/api/image/sendImageUploadPostRequest.ts
+++ b/src/api/image/sendImageUploadPostRequest.ts
@@ -8,7 +8,7 @@ interface ImageUploadResponse {
   imageUrl: string;
 }
 
-const sendImageUploadPostRequest = async (imageFile: File) => {
+const sendImageUploadPostRequest = async (imageFile: FormData) => {
   const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
 
   if (!accessToken) {

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -12,7 +12,10 @@ export const useImageUpload = (url: null | string = null) => {
 
     try {
       const image = event.target.files[0];
-      const { imageUrl } = await sendImageUploadPostRequest(image);
+      const formData = new FormData();
+      formData.append("file", image);
+
+      const { imageUrl } = await sendImageUploadPostRequest(formData);
       setUploadedImageUrl(imageUrl);
     } catch (error) {
       alert("이미지 업로드에 실패했습니다. 다시 시도해 주세요.");


### PR DESCRIPTION
- 이미지 업로드 버그 해결
  - 기존 이미지 `File` 데이터를 그대로 보내는 대신 `FormData`를 보낸다.  