### PR TITLE
Issue 171: api 공통 로직 분리 및 accessToken 런타임 저장

### DIFF
--- a/.github/workflows/front-deploy.yml
+++ b/.github/workflows/front-deploy.yml
@@ -1,0 +1,24 @@
+name: front-deploy
+
+on:
+  push:
+    tags: release-**
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@deploy
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 sync ./build s3://matzip-front/ --acl bucket-owner-full-control

--- a/src/api/axiosInstance.tsx
+++ b/src/api/axiosInstance.tsx
@@ -4,7 +4,7 @@ import { ACCESS_TOKEN, API_BASE_URL } from "constants/api";
 
 import { checkAndSetToken, handleAPIError } from "api/utils";
 
-const axiosInstance = axios.create({
+export const axiosInstance = axios.create({
   baseURL: API_BASE_URL,
 });
 
@@ -18,5 +18,3 @@ export const authAxiosInstance = axios.create({
 });
 
 authAxiosInstance.interceptors.request.use(checkAndSetToken, handleAPIError);
-
-export default axiosInstance;

--- a/src/api/axiosInstance.tsx
+++ b/src/api/axiosInstance.tsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { ACCESS_TOKEN, API_BASE_URL } from "constants/api";
+import { API_BASE_URL } from "constants/api";
 
 import { checkAndSetToken, handleAPIError } from "api/utils";
 
@@ -9,12 +9,4 @@ export const axiosInstance = axios.create({
 });
 
 axiosInstance.interceptors.response.use((response) => response, handleAPIError);
-
-export const authAxiosInstance = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    Authorization: `Bearer ${ACCESS_TOKEN}`,
-  },
-});
-
-authAxiosInstance.interceptors.request.use(checkAndSetToken, handleAPIError);
+axiosInstance.interceptors.request.use(checkAndSetToken, handleAPIError);

--- a/src/api/axiosInstance.tsx
+++ b/src/api/axiosInstance.tsx
@@ -1,17 +1,22 @@
-import axios, { AxiosError, AxiosResponse } from "axios";
+import axios from "axios";
 
-import { API_BASE_URL } from "constants/api";
+import { ACCESS_TOKEN, API_BASE_URL } from "constants/api";
+
+import { checkAndSetToken, handleAPIError } from "api/utils";
 
 const axiosInstance = axios.create({
   baseURL: API_BASE_URL,
 });
 
-const handleAPIError = (error: AxiosError) => {
-  const { data } = error.response as AxiosResponse;
-
-  throw Error(data.message);
-};
-
 axiosInstance.interceptors.response.use((response) => response, handleAPIError);
+
+export const authAxiosInstance = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    Authorization: `Bearer ${ACCESS_TOKEN}`,
+  },
+});
+
+authAxiosInstance.interceptors.request.use(checkAndSetToken, handleAPIError);
 
 export default axiosInstance;

--- a/src/api/bookmark/fetchBookmarkList.ts
+++ b/src/api/bookmark/fetchBookmarkList.ts
@@ -1,14 +1,12 @@
 import type { BookmarkStore } from "types/common/bookmarkTypes";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
 const fetchBookmarkList = async () => {
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-  if (!accessToken) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("다시 로그인 해주세요");
     window.location.href = "/";
     return;
@@ -18,7 +16,7 @@ const fetchBookmarkList = async () => {
     ENDPOINTS.BOOKMARKS,
     {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
       },
     }
   );

--- a/src/api/bookmark/fetchBookmarkList.ts
+++ b/src/api/bookmark/fetchBookmarkList.ts
@@ -1,24 +1,12 @@
 import type { BookmarkStore } from "types/common/bookmarkTypes";
 
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
+import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { authAxiosInstance } from "api/axiosInstance";
 
 const fetchBookmarkList = async () => {
-  if (!ACCESS_TOKEN) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    window.alert("다시 로그인 해주세요");
-    window.location.href = "/";
-    return;
-  }
-
-  const { data } = await axiosInstance.get<BookmarkStore[]>(
-    ENDPOINTS.BOOKMARKS,
-    {
-      headers: {
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
-      },
-    }
+  const { data } = await authAxiosInstance.get<BookmarkStore[]>(
+    ENDPOINTS.BOOKMARKS
   );
 
   return data;

--- a/src/api/bookmark/fetchBookmarkList.ts
+++ b/src/api/bookmark/fetchBookmarkList.ts
@@ -2,11 +2,14 @@ import type { BookmarkStore } from "types/common/bookmarkTypes";
 
 import { ENDPOINTS } from "constants/api";
 
-import { authAxiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const fetchBookmarkList = async () => {
-  const { data } = await authAxiosInstance.get<BookmarkStore[]>(
-    ENDPOINTS.BOOKMARKS
+  const { data } = await axiosInstance.get<BookmarkStore[]>(
+    ENDPOINTS.BOOKMARKS,
+    {
+      useAuth: true,
+    }
   );
 
   return data;

--- a/src/api/bookmark/sendBookmarkDeleteRequest.ts
+++ b/src/api/bookmark/sendBookmarkDeleteRequest.ts
@@ -1,9 +1,11 @@
 import { ENDPOINTS } from "constants/api";
 
-import { authAxiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const sendBookmarkDeleteRequest = (restaurantId: number) => () => {
-  return authAxiosInstance.delete(ENDPOINTS.BOOKMARK_STORE(restaurantId));
+  return axiosInstance.delete(ENDPOINTS.BOOKMARK_STORE(restaurantId), {
+    useAuth: true,
+  });
 };
 
 export default sendBookmarkDeleteRequest;

--- a/src/api/bookmark/sendBookmarkDeleteRequest.ts
+++ b/src/api/bookmark/sendBookmarkDeleteRequest.ts
@@ -1,19 +1,17 @@
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
 const sendBookmarkDeleteRequest = (restaurantId: number) => () => {
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-  if (!accessToken) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("로그인 해주세요");
     window.location.reload();
   }
 
   return axiosInstance.delete(ENDPOINTS.BOOKMARK_STORE(restaurantId), {
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
     },
   });
 };

--- a/src/api/bookmark/sendBookmarkDeleteRequest.ts
+++ b/src/api/bookmark/sendBookmarkDeleteRequest.ts
@@ -1,19 +1,9 @@
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
+import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { authAxiosInstance } from "api/axiosInstance";
 
 const sendBookmarkDeleteRequest = (restaurantId: number) => () => {
-  if (!ACCESS_TOKEN) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    window.alert("로그인 해주세요");
-    window.location.reload();
-  }
-
-  return axiosInstance.delete(ENDPOINTS.BOOKMARK_STORE(restaurantId), {
-    headers: {
-      Authorization: `Bearer ${ACCESS_TOKEN}`,
-    },
-  });
+  return authAxiosInstance.delete(ENDPOINTS.BOOKMARK_STORE(restaurantId));
 };
 
 export default sendBookmarkDeleteRequest;

--- a/src/api/bookmark/sendBookmarkPostRequest.ts
+++ b/src/api/bookmark/sendBookmarkPostRequest.ts
@@ -1,9 +1,11 @@
 import { ENDPOINTS } from "constants/api";
 
-import { authAxiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const sendBookmarkPostRequest = (restaurantId: number) => () => {
-  return authAxiosInstance.post(ENDPOINTS.BOOKMARK_STORE(restaurantId));
+  return axiosInstance.post(ENDPOINTS.BOOKMARK_STORE(restaurantId), {
+    useAuth: true,
+  });
 };
 
 export default sendBookmarkPostRequest;

--- a/src/api/bookmark/sendBookmarkPostRequest.ts
+++ b/src/api/bookmark/sendBookmarkPostRequest.ts
@@ -1,19 +1,9 @@
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
+import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { authAxiosInstance } from "api/axiosInstance";
 
 const sendBookmarkPostRequest = (restaurantId: number) => () => {
-  if (!ACCESS_TOKEN) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    window.alert("로그인 해주세요");
-    window.location.reload();
-  }
-
-  return axiosInstance.post(ENDPOINTS.BOOKMARK_STORE(restaurantId), null, {
-    headers: {
-      Authorization: `Bearer ${ACCESS_TOKEN}`,
-    },
-  });
+  return authAxiosInstance.post(ENDPOINTS.BOOKMARK_STORE(restaurantId));
 };
 
 export default sendBookmarkPostRequest;

--- a/src/api/bookmark/sendBookmarkPostRequest.ts
+++ b/src/api/bookmark/sendBookmarkPostRequest.ts
@@ -1,19 +1,17 @@
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
 const sendBookmarkPostRequest = (restaurantId: number) => () => {
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-  if (!accessToken) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("로그인 해주세요");
     window.location.reload();
   }
 
   return axiosInstance.post(ENDPOINTS.BOOKMARK_STORE(restaurantId), null, {
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
     },
   });
 };

--- a/src/api/image/sendImageUploadPostRequest.ts
+++ b/src/api/image/sendImageUploadPostRequest.ts
@@ -1,30 +1,16 @@
 import { AxiosResponse } from "axios";
 
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
+import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { authAxiosInstance } from "api/axiosInstance";
 
 interface ImageUploadResponse {
   imageUrl: string;
 }
 
 const sendImageUploadPostRequest = async (imageFile: FormData) => {
-  if (!ACCESS_TOKEN) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    window.alert("다시 로그인 해주세요");
-    window.location.reload();
-    throw new Error("엑세스토큰이 유효하지 않습니다");
-  }
-
-  const response: AxiosResponse<ImageUploadResponse> = await axiosInstance.post(
-    ENDPOINTS.IMAGE_UPLOAD,
-    imageFile,
-    {
-      headers: {
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
-      },
-    }
-  );
+  const response: AxiosResponse<ImageUploadResponse> =
+    await authAxiosInstance.post(ENDPOINTS.IMAGE_UPLOAD, imageFile);
 
   return response.data;
 };

--- a/src/api/image/sendImageUploadPostRequest.ts
+++ b/src/api/image/sendImageUploadPostRequest.ts
@@ -2,15 +2,20 @@ import { AxiosResponse } from "axios";
 
 import { ENDPOINTS } from "constants/api";
 
-import { authAxiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 interface ImageUploadResponse {
   imageUrl: string;
 }
 
 const sendImageUploadPostRequest = async (imageFile: FormData) => {
-  const response: AxiosResponse<ImageUploadResponse> =
-    await authAxiosInstance.post(ENDPOINTS.IMAGE_UPLOAD, imageFile);
+  const response: AxiosResponse<ImageUploadResponse> = await axiosInstance.post(
+    ENDPOINTS.IMAGE_UPLOAD,
+    imageFile,
+    {
+      useAuth: true,
+    }
+  );
 
   return response.data;
 };

--- a/src/api/image/sendImageUploadPostRequest.ts
+++ b/src/api/image/sendImageUploadPostRequest.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from "axios";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
@@ -9,10 +9,8 @@ interface ImageUploadResponse {
 }
 
 const sendImageUploadPostRequest = async (imageFile: FormData) => {
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-  if (!accessToken) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("다시 로그인 해주세요");
     window.location.reload();
     throw new Error("엑세스토큰이 유효하지 않습니다");
@@ -23,7 +21,7 @@ const sendImageUploadPostRequest = async (imageFile: FormData) => {
     imageFile,
     {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
       },
     }
   );

--- a/src/api/index.d.ts
+++ b/src/api/index.d.ts
@@ -1,0 +1,7 @@
+import "axios";
+
+declare module "axios" {
+  export interface AxiosRequestConfig {
+    useAuth?: boolean;
+  }
+}

--- a/src/api/login/sendLoginRequest.tsx
+++ b/src/api/login/sendLoginRequest.tsx
@@ -1,7 +1,7 @@
 import { ENDPOINTS } from "constants/api";
 import { MESSAGES } from "constants/messages";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const sendLoginRequest = async (code: string) => {
   const { status, data } = await axiosInstance.get(ENDPOINTS.LOGIN, {

--- a/src/api/mypage/fetchUserProfile.ts
+++ b/src/api/mypage/fetchUserProfile.ts
@@ -1,14 +1,12 @@
 import type { UserProfileInformation } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
 const fetchUserProfile = async () => {
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-  if (!accessToken) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("다시 로그인 해주세요");
     window.location.href = "/";
     return;
@@ -18,7 +16,7 @@ const fetchUserProfile = async () => {
     ENDPOINTS.USER_PROFILE,
     {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
       },
     }
   );

--- a/src/api/mypage/fetchUserProfile.ts
+++ b/src/api/mypage/fetchUserProfile.ts
@@ -1,24 +1,12 @@
 import type { UserProfileInformation } from "types/common";
 
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
+import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { authAxiosInstance } from "api/axiosInstance";
 
 const fetchUserProfile = async () => {
-  if (!ACCESS_TOKEN) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    window.alert("다시 로그인 해주세요");
-    window.location.href = "/";
-    return;
-  }
-
-  const { data } = await axiosInstance.get<UserProfileInformation>(
-    ENDPOINTS.USER_PROFILE,
-    {
-      headers: {
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
-      },
-    }
+  const { data } = await authAxiosInstance.get<UserProfileInformation>(
+    ENDPOINTS.USER_PROFILE
   );
 
   return data;

--- a/src/api/mypage/fetchUserProfile.ts
+++ b/src/api/mypage/fetchUserProfile.ts
@@ -2,11 +2,14 @@ import type { UserProfileInformation } from "types/common";
 
 import { ENDPOINTS } from "constants/api";
 
-import { authAxiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const fetchUserProfile = async () => {
-  const { data } = await authAxiosInstance.get<UserProfileInformation>(
-    ENDPOINTS.USER_PROFILE
+  const { data } = await axiosInstance.get<UserProfileInformation>(
+    ENDPOINTS.USER_PROFILE,
+    {
+      useAuth: true,
+    }
   );
 
   return data;

--- a/src/api/mypage/fetchUserReviewList.ts
+++ b/src/api/mypage/fetchUserReviewList.ts
@@ -3,7 +3,7 @@ import type { UserReview } from "types/common";
 
 import { ENDPOINTS, SIZE } from "constants/api";
 
-import { authAxiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 interface UserReviewResponse {
   hasNext: boolean;
@@ -11,9 +11,10 @@ interface UserReviewResponse {
 }
 
 const fetchUserReviewList = async ({ pageParam = 0 }: FetchParamProps) => {
-  const { data } = await authAxiosInstance.get<UserReviewResponse>(
+  const { data } = await axiosInstance.get<UserReviewResponse>(
     ENDPOINTS.USER_REVIEWS,
     {
+      useAuth: true,
       params: { page: pageParam, size: SIZE.REVIEW },
     }
   );

--- a/src/api/mypage/fetchUserReviewList.ts
+++ b/src/api/mypage/fetchUserReviewList.ts
@@ -1,7 +1,7 @@
 import { FetchParamProps } from "types/apiTypes";
 import type { UserReview } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS, SIZE } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS, SIZE } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
@@ -11,10 +11,8 @@ interface UserReviewResponse {
 }
 
 const fetchUserReviewList = async ({ pageParam = 0 }: FetchParamProps) => {
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-  if (!accessToken) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("다시 로그인 해주세요");
     window.location.href = "/";
     throw new Error("엑세스토큰이 유효하지 않습니다");
@@ -25,7 +23,7 @@ const fetchUserReviewList = async ({ pageParam = 0 }: FetchParamProps) => {
     {
       params: { page: pageParam, size: SIZE.REVIEW },
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
       },
     }
   );

--- a/src/api/mypage/fetchUserReviewList.ts
+++ b/src/api/mypage/fetchUserReviewList.ts
@@ -1,9 +1,9 @@
 import { FetchParamProps } from "types/apiTypes";
 import type { UserReview } from "types/common";
 
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS, SIZE } from "constants/api";
+import { ENDPOINTS, SIZE } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { authAxiosInstance } from "api/axiosInstance";
 
 interface UserReviewResponse {
   hasNext: boolean;
@@ -11,20 +11,10 @@ interface UserReviewResponse {
 }
 
 const fetchUserReviewList = async ({ pageParam = 0 }: FetchParamProps) => {
-  if (!ACCESS_TOKEN) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    window.alert("다시 로그인 해주세요");
-    window.location.href = "/";
-    throw new Error("엑세스토큰이 유효하지 않습니다");
-  }
-
-  const { data } = await axiosInstance.get<UserReviewResponse>(
+  const { data } = await authAxiosInstance.get<UserReviewResponse>(
     ENDPOINTS.USER_REVIEWS,
     {
       params: { page: pageParam, size: SIZE.REVIEW },
-      headers: {
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
-      },
     }
   );
 

--- a/src/api/review/deleteReviewItem.tsx
+++ b/src/api/review/deleteReviewItem.tsx
@@ -1,8 +1,8 @@
 import { AxiosResponse } from "axios";
 
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
+import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { authAxiosInstance } from "api/axiosInstance";
 
 interface DeleteReviewItemProp {
   restaurantId: string;
@@ -13,20 +13,8 @@ const deleteReviewItem = async ({
   restaurantId,
   articleId,
 }: DeleteReviewItemProp) => {
-  if (!ACCESS_TOKEN) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    window.alert("다시 로그인 해주세요");
-    window.location.reload();
-    return;
-  }
-
-  const { data } = await axiosInstance.delete<AxiosResponse>(
-    ENDPOINTS.DELETE_REVIEW_ITEM(restaurantId, articleId),
-    {
-      headers: {
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
-      },
-    }
+  const { data } = await authAxiosInstance.delete<AxiosResponse>(
+    ENDPOINTS.DELETE_REVIEW_ITEM(restaurantId, articleId)
   );
 
   return data;

--- a/src/api/review/deleteReviewItem.tsx
+++ b/src/api/review/deleteReviewItem.tsx
@@ -1,6 +1,6 @@
 import { AxiosResponse } from "axios";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
@@ -13,9 +13,8 @@ const deleteReviewItem = async ({
   restaurantId,
   articleId,
 }: DeleteReviewItemProp) => {
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-  if (!accessToken) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("다시 로그인 해주세요");
     window.location.reload();
     return;
@@ -25,10 +24,11 @@ const deleteReviewItem = async ({
     ENDPOINTS.DELETE_REVIEW_ITEM(restaurantId, articleId),
     {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
       },
     }
   );
+
   return data;
 };
 

--- a/src/api/review/deleteReviewItem.tsx
+++ b/src/api/review/deleteReviewItem.tsx
@@ -2,7 +2,7 @@ import { AxiosResponse } from "axios";
 
 import { ENDPOINTS } from "constants/api";
 
-import { authAxiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 interface DeleteReviewItemProp {
   restaurantId: string;
@@ -13,8 +13,11 @@ const deleteReviewItem = async ({
   restaurantId,
   articleId,
 }: DeleteReviewItemProp) => {
-  const { data } = await authAxiosInstance.delete<AxiosResponse>(
-    ENDPOINTS.DELETE_REVIEW_ITEM(restaurantId, articleId)
+  const { data } = await axiosInstance.delete<AxiosResponse>(
+    ENDPOINTS.DELETE_REVIEW_ITEM(restaurantId, articleId),
+    {
+      useAuth: true,
+    }
   );
 
   return data;

--- a/src/api/review/fetchReviewList.tsx
+++ b/src/api/review/fetchReviewList.tsx
@@ -1,9 +1,9 @@
 import { FetchParamProps } from "types/apiTypes";
 import { ReviewShape } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS, SIZE } from "constants/api";
+import { ACCESS_TOKEN_KEY, ENDPOINTS, SIZE } from "constants/api";
 
-import { authAxiosInstance, axiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 interface ReviewResponseShape {
   hasNext: boolean;
@@ -15,16 +15,20 @@ const fetchReviewList = async ({
   queryKey,
 }: FetchParamProps) => {
   const [, { restaurantId }] = queryKey;
-  const fetchOptions = {
+  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN_KEY);
+
+  const nonUserFetchOptions = {
     params: { page: pageParam, size: SIZE.REVIEW },
   };
 
-  const axiosInstanceToUse =
-    ACCESS_TOKEN === null ? axiosInstance : authAxiosInstance;
+  const userFetchOptions = {
+    ...nonUserFetchOptions,
+    useAuth: true,
+  };
 
-  const { data } = await axiosInstanceToUse.get<ReviewResponseShape>(
+  const { data } = await axiosInstance.get<ReviewResponseShape>(
     ENDPOINTS.REVIEWS(restaurantId),
-    fetchOptions
+    accessToken ? userFetchOptions : nonUserFetchOptions
   );
 
   return { ...data, nextPageParam: pageParam + 1 };

--- a/src/api/review/fetchReviewList.tsx
+++ b/src/api/review/fetchReviewList.tsx
@@ -3,7 +3,7 @@ import { ReviewShape } from "types/common";
 
 import { ACCESS_TOKEN, ENDPOINTS, SIZE } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 interface ReviewResponseShape {
   hasNext: boolean;

--- a/src/api/review/fetchReviewList.tsx
+++ b/src/api/review/fetchReviewList.tsx
@@ -3,7 +3,7 @@ import { ReviewShape } from "types/common";
 
 import { ACCESS_TOKEN, ENDPOINTS, SIZE } from "constants/api";
 
-import { axiosInstance } from "api/axiosInstance";
+import { authAxiosInstance, axiosInstance } from "api/axiosInstance";
 
 interface ReviewResponseShape {
   hasNext: boolean;
@@ -15,20 +15,16 @@ const fetchReviewList = async ({
   queryKey,
 }: FetchParamProps) => {
   const [, { restaurantId }] = queryKey;
-  const nonUserFetchOptions = {
+  const fetchOptions = {
     params: { page: pageParam, size: SIZE.REVIEW },
   };
 
-  const userFetchOptions = {
-    ...nonUserFetchOptions,
-    headers: {
-      Authorization: `Bearer ${ACCESS_TOKEN}`,
-    },
-  };
+  const axiosInstanceToUse =
+    ACCESS_TOKEN === null ? axiosInstance : authAxiosInstance;
 
-  const { data } = await axiosInstance.get<ReviewResponseShape>(
+  const { data } = await axiosInstanceToUse.get<ReviewResponseShape>(
     ENDPOINTS.REVIEWS(restaurantId),
-    ACCESS_TOKEN === null ? nonUserFetchOptions : userFetchOptions
+    fetchOptions
   );
 
   return { ...data, nextPageParam: pageParam + 1 };

--- a/src/api/review/fetchReviewList.tsx
+++ b/src/api/review/fetchReviewList.tsx
@@ -15,8 +15,6 @@ const fetchReviewList = async ({
   queryKey,
 }: FetchParamProps) => {
   const [, { restaurantId }] = queryKey;
-  const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
-
   const nonUserFetchOptions = {
     params: { page: pageParam, size: SIZE.REVIEW },
   };
@@ -24,14 +22,15 @@ const fetchReviewList = async ({
   const userFetchOptions = {
     ...nonUserFetchOptions,
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
     },
   };
 
   const { data } = await axiosInstance.get<ReviewResponseShape>(
     ENDPOINTS.REVIEWS(restaurantId),
-    accessToken === null ? nonUserFetchOptions : userFetchOptions
+    ACCESS_TOKEN === null ? nonUserFetchOptions : userFetchOptions
   );
+
   return { ...data, nextPageParam: pageParam + 1 };
 };
 

--- a/src/api/review/sendReviewItem.tsx
+++ b/src/api/review/sendReviewItem.tsx
@@ -1,8 +1,8 @@
 import { AxiosResponse } from "axios";
 
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
+import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { authAxiosInstance } from "api/axiosInstance";
 
 interface SendReviewItemProps {
   restaurantId: string;
@@ -19,23 +19,12 @@ const sendReviewItem = async ({
   rating,
   menu,
 }: SendReviewItemProps) => {
-  if (!ACCESS_TOKEN) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-    window.alert("다시 로그인 해주세요");
-    window.location.reload();
-    return;
-  }
-  const { data } = await axiosInstance.put<AxiosResponse>(
+  const { data } = await authAxiosInstance.put<AxiosResponse>(
     ENDPOINTS.UPDATE_REVIEW_ITEM(restaurantId, articleId),
     {
       content: content,
       rating: rating,
       menu: menu,
-    },
-    {
-      headers: {
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
-      },
     }
   );
 

--- a/src/api/review/sendReviewItem.tsx
+++ b/src/api/review/sendReviewItem.tsx
@@ -2,7 +2,7 @@ import { AxiosResponse } from "axios";
 
 import { ENDPOINTS } from "constants/api";
 
-import { authAxiosInstance } from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 interface SendReviewItemProps {
   restaurantId: string;
@@ -19,12 +19,15 @@ const sendReviewItem = async ({
   rating,
   menu,
 }: SendReviewItemProps) => {
-  const { data } = await authAxiosInstance.put<AxiosResponse>(
+  const { data } = await axiosInstance.put<AxiosResponse>(
     ENDPOINTS.UPDATE_REVIEW_ITEM(restaurantId, articleId),
     {
       content: content,
       rating: rating,
       menu: menu,
+    },
+    {
+      useAuth: true,
     }
   );
 

--- a/src/api/review/sendReviewItem.tsx
+++ b/src/api/review/sendReviewItem.tsx
@@ -1,6 +1,6 @@
 import { AxiosResponse } from "axios";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
@@ -19,9 +19,8 @@ const sendReviewItem = async ({
   rating,
   menu,
 }: SendReviewItemProps) => {
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-  if (!accessToken) {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("다시 로그인 해주세요");
     window.location.reload();
     return;
@@ -35,10 +34,11 @@ const sendReviewItem = async ({
     },
     {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
       },
     }
   );
+
   return data;
 };
 

--- a/src/api/review/sendReviewPostRequest.tsx
+++ b/src/api/review/sendReviewPostRequest.tsx
@@ -2,7 +2,7 @@ import { ReviewInputShape } from "types/common";
 
 import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const sendReviewPostRequest =
   (restaurantId: string) => (newReview: ReviewInputShape) => {

--- a/src/api/review/sendReviewPostRequest.tsx
+++ b/src/api/review/sendReviewPostRequest.tsx
@@ -1,21 +1,21 @@
 import { ReviewInputShape } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
 const sendReviewPostRequest =
   (restaurantId: string) => (newReview: ReviewInputShape) => {
-    const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-    if (!accessToken) {
-      window.sessionStorage.removeItem(ACCESS_TOKEN);
+    if (!ACCESS_TOKEN) {
+      window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
       window.alert("다시 로그인 해주세요");
       window.location.reload();
       throw new Error("엑세스토큰이 유효하지 않습니다");
     }
+
     return axiosInstance.post(ENDPOINTS.REVIEWS(restaurantId), newReview, {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
       },
     });
   };

--- a/src/api/review/sendReviewPostRequest.tsx
+++ b/src/api/review/sendReviewPostRequest.tsx
@@ -1,23 +1,12 @@
 import { ReviewInputShape } from "types/common";
 
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
+import { ENDPOINTS } from "constants/api";
 
 import axiosInstance from "api/axiosInstance";
 
 const sendReviewPostRequest =
   (restaurantId: string) => (newReview: ReviewInputShape) => {
-    if (!ACCESS_TOKEN) {
-      window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-      window.alert("다시 로그인 해주세요");
-      window.location.reload();
-      throw new Error("엑세스토큰이 유효하지 않습니다");
-    }
-
-    return axiosInstance.post(ENDPOINTS.REVIEWS(restaurantId), newReview, {
-      headers: {
-        Authorization: `Bearer ${ACCESS_TOKEN}`,
-      },
-    });
+    return axiosInstance.post(ENDPOINTS.REVIEWS(restaurantId), newReview);
   };
 
 export default sendReviewPostRequest;

--- a/src/api/review/sendReviewPostRequest.tsx
+++ b/src/api/review/sendReviewPostRequest.tsx
@@ -6,7 +6,9 @@ import { axiosInstance } from "api/axiosInstance";
 
 const sendReviewPostRequest =
   (restaurantId: string) => (newReview: ReviewInputShape) => {
-    return axiosInstance.post(ENDPOINTS.REVIEWS(restaurantId), newReview);
+    return axiosInstance.post(ENDPOINTS.REVIEWS(restaurantId), newReview, {
+      useAuth: true,
+    });
   };
 
 export default sendReviewPostRequest;

--- a/src/api/store/fetchRandomStoreList.tsx
+++ b/src/api/store/fetchRandomStoreList.tsx
@@ -2,7 +2,7 @@ import { CampusId, Store } from "types/common";
 
 import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const fetchRandomStoreList = async (campusId: CampusId, size: number) => {
   const userFetchOptions = {

--- a/src/api/store/fetchRandomStoreList.tsx
+++ b/src/api/store/fetchRandomStoreList.tsx
@@ -5,17 +5,15 @@ import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
 import axiosInstance from "api/axiosInstance";
 
 const fetchRandomStoreList = async (campusId: CampusId, size: number) => {
-  const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
-
   const userFetchOptions = {
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
     },
   };
 
   const { data } = await axiosInstance.get<Store[]>(
     ENDPOINTS.RANDOM_STORES(campusId, size),
-    accessToken ? userFetchOptions : undefined
+    ACCESS_TOKEN ? userFetchOptions : undefined
   );
 
   return data;

--- a/src/api/store/fetchRandomStoreList.tsx
+++ b/src/api/store/fetchRandomStoreList.tsx
@@ -1,19 +1,17 @@
 import { CampusId, Store } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import { axiosInstance } from "api/axiosInstance";
 
 const fetchRandomStoreList = async (campusId: CampusId, size: number) => {
-  const userFetchOptions = {
-    headers: {
-      Authorization: `Bearer ${ACCESS_TOKEN}`,
-    },
-  };
+  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN_KEY);
 
   const { data } = await axiosInstance.get<Store[]>(
     ENDPOINTS.RANDOM_STORES(campusId, size),
-    ACCESS_TOKEN ? userFetchOptions : undefined
+    {
+      useAuth: !!accessToken,
+    }
   );
 
   return data;

--- a/src/api/store/fetchStoreDemandList.tsx
+++ b/src/api/store/fetchStoreDemandList.tsx
@@ -3,7 +3,7 @@ import { CategoryId } from "types/common";
 
 import { ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 interface StoreDemandGetResponse {
   items: StoreItemType[];

--- a/src/api/store/fetchStoreDetail.tsx
+++ b/src/api/store/fetchStoreDetail.tsx
@@ -2,7 +2,7 @@ import { Store } from "types/common";
 
 import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const fetchStoreDetail = async (restaurantId: string) => {
   const userFetchOptions = {

--- a/src/api/store/fetchStoreDetail.tsx
+++ b/src/api/store/fetchStoreDetail.tsx
@@ -5,17 +5,15 @@ import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
 import axiosInstance from "api/axiosInstance";
 
 const fetchStoreDetail = async (restaurantId: string) => {
-  const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
-
   const userFetchOptions = {
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
     },
   };
 
   const { data } = await axiosInstance.get<Store & { address: string }>(
     ENDPOINTS.STORE_DETAIL(restaurantId),
-    accessToken ? userFetchOptions : undefined
+    ACCESS_TOKEN ? userFetchOptions : undefined
   );
 
   return data;

--- a/src/api/store/fetchStoreDetail.tsx
+++ b/src/api/store/fetchStoreDetail.tsx
@@ -1,19 +1,17 @@
 import { Store } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import { axiosInstance } from "api/axiosInstance";
 
 const fetchStoreDetail = async (restaurantId: string) => {
-  const userFetchOptions = {
-    headers: {
-      Authorization: `Bearer ${ACCESS_TOKEN}`,
-    },
-  };
+  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN_KEY);
 
   const { data } = await axiosInstance.get<Store & { address: string }>(
     ENDPOINTS.STORE_DETAIL(restaurantId),
-    ACCESS_TOKEN ? userFetchOptions : undefined
+    {
+      useAuth: !!accessToken,
+    }
   );
 
   return data;

--- a/src/api/store/fetchStoreList.tsx
+++ b/src/api/store/fetchStoreList.tsx
@@ -1,7 +1,7 @@
 import { FetchParamProps } from "types/apiTypes";
 import { CampusId, Store } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
+import { ACCESS_TOKEN_KEY, ENDPOINTS } from "constants/api";
 
 import { axiosInstance } from "api/axiosInstance";
 
@@ -33,6 +33,7 @@ const generateParams = (propObject: GenerateParamsProps) =>
   );
 
 const fetchStoreList = async ({ pageParam = 0, queryKey }: FetchParamProps) => {
+  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN_KEY);
   const [, { size, filter, campusId, categoryId, name, type }] = queryKey;
   const params = generateParams({
     page: pageParam,
@@ -47,14 +48,12 @@ const fetchStoreList = async ({ pageParam = 0, queryKey }: FetchParamProps) => {
 
   const userFetchOptions = {
     ...nonUserFetchOptions,
-    headers: {
-      Authorization: `Bearer ${ACCESS_TOKEN}`,
-    },
+    useAuth: true,
   };
 
   const { data } = await axiosInstance.get<CategoryStoreListResponse>(
     ENDPOINTS.STORE_LIST(campusId, type),
-    ACCESS_TOKEN ? userFetchOptions : nonUserFetchOptions
+    accessToken ? userFetchOptions : nonUserFetchOptions
   );
 
   return { ...data, nextPageParam: pageParam + 1 };

--- a/src/api/store/fetchStoreList.tsx
+++ b/src/api/store/fetchStoreList.tsx
@@ -33,7 +33,6 @@ const generateParams = (propObject: GenerateParamsProps) =>
   );
 
 const fetchStoreList = async ({ pageParam = 0, queryKey }: FetchParamProps) => {
-  const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
   const [, { size, filter, campusId, categoryId, name, type }] = queryKey;
   const params = generateParams({
     page: pageParam,
@@ -49,13 +48,13 @@ const fetchStoreList = async ({ pageParam = 0, queryKey }: FetchParamProps) => {
   const userFetchOptions = {
     ...nonUserFetchOptions,
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
     },
   };
 
   const { data } = await axiosInstance.get<CategoryStoreListResponse>(
     ENDPOINTS.STORE_LIST(campusId, type),
-    accessToken ? userFetchOptions : nonUserFetchOptions
+    ACCESS_TOKEN ? userFetchOptions : nonUserFetchOptions
   );
 
   return { ...data, nextPageParam: pageParam + 1 };

--- a/src/api/store/fetchStoreList.tsx
+++ b/src/api/store/fetchStoreList.tsx
@@ -3,7 +3,7 @@ import { CampusId, Store } from "types/common";
 
 import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 type ReduceReturnType = Record<string, any>;
 

--- a/src/api/store/sendStoreDemandDeleteRequest.tsx
+++ b/src/api/store/sendStoreDemandDeleteRequest.tsx
@@ -3,7 +3,7 @@ import { CampusId } from "types/common";
 import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
 import { MESSAGES } from "constants/messages";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const sendStoreDemandDeleteRequest =
   (campusId: CampusId, storeRequestId: string) => () => {

--- a/src/api/store/sendStoreDemandDeleteRequest.tsx
+++ b/src/api/store/sendStoreDemandDeleteRequest.tsx
@@ -7,9 +7,7 @@ import axiosInstance from "api/axiosInstance";
 
 const sendStoreDemandDeleteRequest =
   (campusId: CampusId, storeRequestId: string) => () => {
-    const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-    if (typeof accessToken !== "string") {
+    if (typeof ACCESS_TOKEN !== "string") {
       throw new Error(MESSAGES.TOKEN_INVALID);
     }
 
@@ -17,7 +15,7 @@ const sendStoreDemandDeleteRequest =
       `${ENDPOINTS.STORE_REQUESTS(campusId)}/${storeRequestId}`,
       {
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
         },
       }
     );

--- a/src/api/store/sendStoreDemandDeleteRequest.tsx
+++ b/src/api/store/sendStoreDemandDeleteRequest.tsx
@@ -1,22 +1,15 @@
 import { CampusId } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
-import { MESSAGES } from "constants/messages";
+import { ENDPOINTS } from "constants/api";
 
 import { axiosInstance } from "api/axiosInstance";
 
 const sendStoreDemandDeleteRequest =
   (campusId: CampusId, storeRequestId: string) => () => {
-    if (typeof ACCESS_TOKEN !== "string") {
-      throw new Error(MESSAGES.TOKEN_INVALID);
-    }
-
     return axiosInstance.delete(
       `${ENDPOINTS.STORE_REQUESTS(campusId)}/${storeRequestId}`,
       {
-        headers: {
-          Authorization: `Bearer ${ACCESS_TOKEN}`,
-        },
+        useAuth: true,
       }
     );
   };

--- a/src/api/store/sendStoreDemandPostRequest.tsx
+++ b/src/api/store/sendStoreDemandPostRequest.tsx
@@ -8,9 +8,7 @@ import axiosInstance from "api/axiosInstance";
 const sendStoreDemandPostRequest =
   (campusId: CampusId) =>
   (storeRequestData: { categoryId: string; name: string }) => {
-    const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-    if (typeof accessToken !== "string") {
+    if (typeof ACCESS_TOKEN !== "string") {
       throw new Error(MESSAGES.TOKEN_INVALID);
     }
 
@@ -19,7 +17,7 @@ const sendStoreDemandPostRequest =
       storeRequestData,
       {
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
         },
       }
     );

--- a/src/api/store/sendStoreDemandPostRequest.tsx
+++ b/src/api/store/sendStoreDemandPostRequest.tsx
@@ -1,24 +1,17 @@
 import { CampusId } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
-import { MESSAGES } from "constants/messages";
+import { ENDPOINTS } from "constants/api";
 
 import { axiosInstance } from "api/axiosInstance";
 
 const sendStoreDemandPostRequest =
   (campusId: CampusId) =>
   (storeRequestData: { categoryId: string; name: string }) => {
-    if (typeof ACCESS_TOKEN !== "string") {
-      throw new Error(MESSAGES.TOKEN_INVALID);
-    }
-
     return axiosInstance.post(
       ENDPOINTS.STORE_REQUESTS(campusId),
       storeRequestData,
       {
-        headers: {
-          Authorization: `Bearer ${ACCESS_TOKEN}`,
-        },
+        useAuth: true,
       }
     );
   };

--- a/src/api/store/sendStoreDemandPostRequest.tsx
+++ b/src/api/store/sendStoreDemandPostRequest.tsx
@@ -3,7 +3,7 @@ import { CampusId } from "types/common";
 import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
 import { MESSAGES } from "constants/messages";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const sendStoreDemandPostRequest =
   (campusId: CampusId) =>

--- a/src/api/store/sendStoreDemandPutRequest.tsx
+++ b/src/api/store/sendStoreDemandPutRequest.tsx
@@ -1,24 +1,17 @@
 import { CampusId } from "types/common";
 
-import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
-import { MESSAGES } from "constants/messages";
+import { ENDPOINTS } from "constants/api";
 
 import { axiosInstance } from "api/axiosInstance";
 
 const sendStoreDemandPutRequest =
   (campusId: CampusId, storeRequestId: string) =>
   (storeRequestData: { categoryId: string; name: string }) => {
-    if (typeof ACCESS_TOKEN !== "string") {
-      throw new Error(MESSAGES.TOKEN_INVALID);
-    }
-
     return axiosInstance.put(
       `${ENDPOINTS.STORE_REQUESTS(campusId)}/${storeRequestId}`,
       storeRequestData,
       {
-        headers: {
-          Authorization: `Bearer ${ACCESS_TOKEN}`,
-        },
+        useAuth: true,
       }
     );
   };

--- a/src/api/store/sendStoreDemandPutRequest.tsx
+++ b/src/api/store/sendStoreDemandPutRequest.tsx
@@ -3,7 +3,7 @@ import { CampusId } from "types/common";
 import { ACCESS_TOKEN, ENDPOINTS } from "constants/api";
 import { MESSAGES } from "constants/messages";
 
-import axiosInstance from "api/axiosInstance";
+import { axiosInstance } from "api/axiosInstance";
 
 const sendStoreDemandPutRequest =
   (campusId: CampusId, storeRequestId: string) =>

--- a/src/api/store/sendStoreDemandPutRequest.tsx
+++ b/src/api/store/sendStoreDemandPutRequest.tsx
@@ -8,9 +8,7 @@ import axiosInstance from "api/axiosInstance";
 const sendStoreDemandPutRequest =
   (campusId: CampusId, storeRequestId: string) =>
   (storeRequestData: { categoryId: string; name: string }) => {
-    const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
-    if (typeof accessToken !== "string") {
+    if (typeof ACCESS_TOKEN !== "string") {
       throw new Error(MESSAGES.TOKEN_INVALID);
     }
 
@@ -19,7 +17,7 @@ const sendStoreDemandPutRequest =
       storeRequestData,
       {
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
         },
       }
     );

--- a/src/api/utils/index.ts
+++ b/src/api/utils/index.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import type { AxiosError, AxiosRequestConfig } from "axios";
 
 import { ACCESS_TOKEN_KEY } from "constants/api";
 
@@ -12,7 +12,7 @@ export const checkAndSetToken = (config: AxiosRequestConfig) => {
   if (accessToken === null) {
     window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("다시 로그인 해주세요");
-    // window.location.reload();
+    window.location.reload();
     throw new Error("엑세스토큰이 유효하지 않습니다");
   }
 
@@ -21,8 +21,14 @@ export const checkAndSetToken = (config: AxiosRequestConfig) => {
   return config;
 };
 
-export const handleAPIError = (error: AxiosError) => {
-  const { data } = error.response as AxiosResponse;
+interface ErrorResponseData {
+  message?: string;
+}
+
+export const handleAPIError = (error: AxiosError<ErrorResponseData>) => {
+  if (!error.response) throw Error("에러가 발생했습니다.");
+
+  const { data } = error.response;
 
   throw Error(data.message);
 };

--- a/src/api/utils/index.ts
+++ b/src/api/utils/index.ts
@@ -1,4 +1,4 @@
-import type { AxiosRequestConfig } from "axios";
+import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { ACCESS_TOKEN, ACCESS_TOKEN_KEY } from "constants/api";
 
@@ -17,4 +17,10 @@ export const checkAndSetToken = (config: AxiosRequestConfig) => {
   config.headers.Authorization = `Bearer ${ACCESS_TOKEN}`;
 
   return config;
+};
+
+export const handleAPIError = (error: AxiosError) => {
+  const { data } = error.response as AxiosResponse;
+
+  throw Error(data.message);
 };

--- a/src/api/utils/index.ts
+++ b/src/api/utils/index.ts
@@ -1,0 +1,20 @@
+import type { AxiosRequestConfig } from "axios";
+
+import { ACCESS_TOKEN, ACCESS_TOKEN_KEY } from "constants/api";
+
+export const checkAndSetToken = (config: AxiosRequestConfig) => {
+  if (!config.headers || !Object.hasOwn(config.headers, "Authorization")) {
+    return config;
+  }
+
+  if (!ACCESS_TOKEN) {
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    window.alert("다시 로그인 해주세요");
+    window.location.reload();
+    throw new Error("엑세스토큰이 유효하지 않습니다");
+  }
+
+  config.headers.Authorization = `Bearer ${ACCESS_TOKEN}`;
+
+  return config;
+};

--- a/src/api/utils/index.ts
+++ b/src/api/utils/index.ts
@@ -1,20 +1,22 @@
 import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 
-import { ACCESS_TOKEN, ACCESS_TOKEN_KEY } from "constants/api";
+import { ACCESS_TOKEN_KEY } from "constants/api";
 
 export const checkAndSetToken = (config: AxiosRequestConfig) => {
-  if (!config.headers || !Object.hasOwn(config.headers, "Authorization")) {
+  if (!config.headers || !config.useAuth) {
     return config;
   }
 
-  if (!ACCESS_TOKEN) {
+  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN_KEY);
+
+  if (accessToken === null) {
     window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     window.alert("다시 로그인 해주세요");
-    window.location.reload();
+    // window.location.reload();
     throw new Error("엑세스토큰이 유효하지 않습니다");
   }
 
-  config.headers.Authorization = `Bearer ${ACCESS_TOKEN}`;
+  config.headers.Authorization = `Bearer ${accessToken}`;
 
   return config;
 };

--- a/src/components/common/StoreListItem/StoreListItem.tsx
+++ b/src/components/common/StoreListItem/StoreListItem.tsx
@@ -36,8 +36,6 @@ function StoreListItem({
   const navigate = useNavigate();
   const campusName = useContext(campusContext);
 
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
   return (
     <S.ListItemContainer
       onClick={() => {
@@ -65,7 +63,7 @@ function StoreListItem({
         </Text>
       </S.ListItemTextContainer>
       <S.ListItemBookmark onClick={handleMarked}>
-        {accessToken && marked ? (
+        {ACCESS_TOKEN && marked ? (
           <Heart size="sm" isFilled />
         ) : (
           <Heart size="sm" />

--- a/src/components/common/StoreListItem/StoreListItem.tsx
+++ b/src/components/common/StoreListItem/StoreListItem.tsx
@@ -5,10 +5,10 @@ import { useNavigate } from "react-router-dom";
 import type { Store } from "types/common";
 import { getRandomEmptyReviewMessage } from "util/randomUtils";
 
-import { ACCESS_TOKEN } from "constants/api";
 import { PATHNAME } from "constants/routes";
 
 import { campusContext } from "context/CampusContextProvider";
+import { LoginContext } from "context/LoginContextProvider";
 
 import { useMarked } from "hooks/useMarked";
 
@@ -32,9 +32,10 @@ function StoreListItem({
   reviewCount,
   liked,
 }: StoreListItemProps) {
+  const isLoggedIn = useContext(LoginContext);
+  const campusName = useContext(campusContext);
   const { marked, handleMarked } = useMarked(id, liked);
   const navigate = useNavigate();
-  const campusName = useContext(campusContext);
 
   return (
     <S.ListItemContainer
@@ -63,7 +64,7 @@ function StoreListItem({
         </Text>
       </S.ListItemTextContainer>
       <S.ListItemBookmark onClick={handleMarked}>
-        {ACCESS_TOKEN && marked ? (
+        {isLoggedIn && marked ? (
           <Heart size="sm" isFilled />
         ) : (
           <Heart size="sm" />

--- a/src/components/pages/StoreDetailPage/StoreDetailTitle/StoreDetailTitle.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailTitle/StoreDetailTitle.tsx
@@ -33,13 +33,11 @@ function StoreDetailTitle({
   const { marked, handleMarked } = useMarked(id, liked);
   const campus = useContext(campusContext);
 
-  const accessToken = window.sessionStorage.getItem(ACCESS_TOKEN);
-
   return (
     <S.TitleContainer>
       <Heading size="sm">{name}</Heading>
       <S.BookmarkIconWrapper onClick={handleMarked}>
-        {accessToken && marked ? (
+        {ACCESS_TOKEN && marked ? (
           <Heart size="sm" isFilled />
         ) : (
           <Heart size="sm" />

--- a/src/components/pages/StoreDetailPage/StoreDetailTitle/StoreDetailTitle.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailTitle/StoreDetailTitle.tsx
@@ -3,9 +3,8 @@ import { Store } from "types/common";
 import { getRandomEmptyReviewMessage } from "util/randomUtils";
 import repeatComponent from "util/repeatComponent";
 
-import { ACCESS_TOKEN } from "constants/api";
-
 import { campusContext } from "context/CampusContextProvider";
+import { LoginContext } from "context/LoginContextProvider";
 
 import { useMarked } from "hooks/useMarked";
 
@@ -30,14 +29,15 @@ function StoreDetailTitle({
 }: {
   storeInfo: Store;
 }) {
-  const { marked, handleMarked } = useMarked(id, liked);
+  const isLoggedIn = useContext(LoginContext);
   const campus = useContext(campusContext);
+  const { marked, handleMarked } = useMarked(id, liked);
 
   return (
     <S.TitleContainer>
       <Heading size="sm">{name}</Heading>
       <S.BookmarkIconWrapper onClick={handleMarked}>
-        {ACCESS_TOKEN && marked ? (
+        {isLoggedIn && marked ? (
           <Heart size="sm" isFilled />
         ) : (
           <Heart size="sm" />

--- a/src/constants/api.tsx
+++ b/src/constants/api.tsx
@@ -41,7 +41,6 @@ export const FILTERS = [
 ] as const;
 
 export const ACCESS_TOKEN_KEY = "matzipaccessToken";
-export const ACCESS_TOKEN = window.sessionStorage.getItem(ACCESS_TOKEN_KEY);
 
 export const AUTH_LINK = `https://github.com/login/oauth/authorize?client_id=${
   process.env.NODE_ENV === "production"

--- a/src/constants/api.tsx
+++ b/src/constants/api.tsx
@@ -40,7 +40,8 @@ export const FILTERS = [
   { order: "spell", text: "가나다 순" },
 ] as const;
 
-export const ACCESS_TOKEN = "matzipaccessToken";
+export const ACCESS_TOKEN_KEY = "matzipaccessToken";
+export const ACCESS_TOKEN = window.sessionStorage.getItem(ACCESS_TOKEN_KEY);
 
 export const AUTH_LINK = `https://github.com/login/oauth/authorize?client_id=${
   process.env.NODE_ENV === "production"

--- a/src/context/LoginContextProvider.tsx
+++ b/src/context/LoginContextProvider.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 
-import { ACCESS_TOKEN } from "constants/api";
+import { ACCESS_TOKEN_KEY } from "constants/api";
 
-const hasAccessToken = !!ACCESS_TOKEN;
+const hasAccessToken = !!window.sessionStorage.getItem(ACCESS_TOKEN_KEY);
 
 export const LoginContext = React.createContext<boolean>(false);
 export const SetLoginContext = React.createContext<

--- a/src/context/LoginContextProvider.tsx
+++ b/src/context/LoginContextProvider.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import { ACCESS_TOKEN } from "constants/api";
 
-const hasAccessToken = !!window.sessionStorage.getItem(ACCESS_TOKEN);
+const hasAccessToken = !!ACCESS_TOKEN;
 
 export const LoginContext = React.createContext<boolean>(false);
 export const SetLoginContext = React.createContext<

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 
-import { ACCESS_TOKEN } from "constants/api";
+import { ACCESS_TOKEN_KEY } from "constants/api";
 
 import { SetLoginContext } from "context/LoginContextProvider";
 
@@ -8,12 +8,12 @@ const useLogin = () => {
   const setIsLoggedIn = useContext(SetLoginContext);
 
   const login = (accessToken: string) => {
-    window.sessionStorage.setItem(ACCESS_TOKEN, accessToken);
+    window.sessionStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
     setIsLoggedIn(true);
   };
 
   const logout = () => {
-    window.sessionStorage.removeItem(ACCESS_TOKEN);
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
     setIsLoggedIn(false);
   };
 


### PR DESCRIPTION
### Issue #171 

- `accessToken`을 런타임에서 들고 있는다
- api 함수에서 공통된 로직을 axios interceptor를 이용하거나 유틸 함수로 분리한다
- `Authorization: Bearer ${accessToken}`을 api 요청 보내기 전에 미리 처리한다