### PR TITLE
Issue191 식당 상세 페이지 데이터 패칭 과정 개선

### DIFF
--- a/src/components/common/ImageSkeleton/ImageSkeleton.style.ts
+++ b/src/components/common/ImageSkeleton/ImageSkeleton.style.ts
@@ -1,0 +1,45 @@
+import styled, { css, keyframes } from "styled-components";
+
+const wave = keyframes`
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+`;
+
+interface ImageSkeletonProps {
+  $width?: string;
+  $height?: string;
+}
+
+export const ImageSkeleton = styled.div<ImageSkeletonProps>`
+  width: ${({ $width }) => $width || "100%"};
+  height: ${({ $height }) => $height || "100%"};
+
+  background: ${({ theme }) => css`
+    linear-gradient(
+      90deg,
+      ${theme.color.gray500},
+      ${theme.color.gray100},
+      ${theme.color.gray500},
+      ${theme.color.gray100}
+    );
+  `};
+  background-size: 200% 200%;
+  animation: ${wave} 4s ease infinite;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const LoadingText = styled.p`
+  color: ${({ theme }) => theme.color.gray500};
+  font-size: 1.3rem;
+  line-height: 1.3;
+`;

--- a/src/components/common/ImageSkeleton/ImageSkeleton.tsx
+++ b/src/components/common/ImageSkeleton/ImageSkeleton.tsx
@@ -1,0 +1,12 @@
+import * as S from "./ImageSkeleton.style";
+
+interface ImageSkeletonProps {
+  width?: string;
+  height?: string;
+}
+
+function ImageSkeleton({ width, height }: ImageSkeletonProps) {
+  return <S.ImageSkeleton $width={width} $height={height} />;
+}
+
+export default ImageSkeleton;

--- a/src/components/common/Spinner/Spinner.style.tsx
+++ b/src/components/common/Spinner/Spinner.style.tsx
@@ -1,15 +1,27 @@
-import styled from "styled-components";
+import { SpinnerPosition } from "./Spinner";
 
-export const SpinnerContainer = styled.div`
+import styled, { css } from "styled-components";
+
+export const SpinnerContainer = styled.div<{ $position: SpinnerPosition }>`
   display: flex;
   justify-content: center;
   align-items: center;
 
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  ${({ $position }) =>
+    $position === "static" &&
+    css`
+      padding: 2rem 0;
+    `}
+
+  ${({ $position }) =>
+    $position === "fixed" &&
+    css`
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    `}
 `;
 
 export const SpinDiv = styled.div`

--- a/src/components/common/Spinner/Spinner.tsx
+++ b/src/components/common/Spinner/Spinner.tsx
@@ -1,8 +1,14 @@
 import * as S from "components/common/Spinner/Spinner.style";
 
-function Spinner() {
+export type SpinnerPosition = "static" | "fixed";
+
+interface SpinnerProps {
+  position?: SpinnerPosition;
+}
+
+function Spinner({ position = "fixed" }: SpinnerProps) {
   return (
-    <S.SpinnerContainer>
+    <S.SpinnerContainer $position={position}>
       <S.SpinDiv />
     </S.SpinnerContainer>
   );

--- a/src/components/pages/StoreDetailPage/StoreDetailPage.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailPage.tsx
@@ -97,41 +97,39 @@ function StoreDetailPage() {
           <Heading size="xs">리뷰</Heading>
           <S.ReviewListWrapper>
             <InfiniteScroll handleContentLoad={loadMoreReviews} hasMore={true}>
-              {(isLoading || isFetching) && <Spinner />}
               {isError && error instanceof Error && (
                 <ErrorImage errorMessage={error.message} />
               )}
-              {reviews.length ? (
-                reviews.map(
-                  ({
-                    id,
-                    author,
-                    rating,
-                    content,
-                    menu,
-                    imageUrl,
-                    updatable,
-                  }) => (
-                    <Fragment key={id}>
-                      <StoreReviewItem
-                        reviewInfo={{
-                          restaurantId,
-                          id,
-                          author,
-                          rating,
-                          content,
-                          menu,
-                          imageUrl,
-                          updatable,
-                        }}
-                      />
-                      <Divider />
-                    </Fragment>
+              {reviews.length
+                ? reviews.map(
+                    ({
+                      id,
+                      author,
+                      rating,
+                      content,
+                      menu,
+                      imageUrl,
+                      updatable,
+                    }) => (
+                      <Fragment key={id}>
+                        <StoreReviewItem
+                          reviewInfo={{
+                            restaurantId,
+                            id,
+                            author,
+                            rating,
+                            content,
+                            menu,
+                            imageUrl,
+                            updatable,
+                          }}
+                        />
+                        <Divider />
+                      </Fragment>
+                    )
                   )
-                )
-              ) : (
-                <ErrorText>작성된 리뷰가 없습니다.</ErrorText>
-              )}
+                : !isFetching && <ErrorText>작성된 리뷰가 없습니다.</ErrorText>}
+              {(isLoading || isFetching) && <Spinner position="static" />}
             </InfiniteScroll>
           </S.ReviewListWrapper>
         </S.ReviewListContainer>

--- a/src/components/pages/StoreDetailPage/StoreDetailPage.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useContext, useState } from "react";
+import { Fragment, useContext, useState, useRef, useEffect } from "react";
 import { useInfiniteQuery, useQuery } from "react-query";
 import { useParams } from "react-router-dom";
 import { ReviewShape } from "types/common";
@@ -30,16 +30,23 @@ import StoreReviewItem from "components/pages/StoreDetailPage/StoreReviewItem/St
 
 function StoreDetailPage() {
   const { storeId: restaurantId } = useParams();
-  const [isReviewOpen, setIsReviewOpen] = useState(false);
-  const isLoggedIn = useContext(LoginContext);
+  const previousRestaurantId = useRef<string | undefined | null>(null);
+
+  useEffect(() => {
+    previousRestaurantId.current = restaurantId;
+  }, [restaurantId]);
 
   const { data: storeData, isFetching: isStoreFetching } = useQuery(
     "storeDetailInfo",
     () => fetchStoreDetail(restaurantId as string),
     {
       retry: NETWORK.RETRY_COUNT,
+      enabled: restaurantId !== previousRestaurantId.current,
     }
   );
+
+  const [isReviewOpen, setIsReviewOpen] = useState(false);
+  const isLoggedIn = useContext(LoginContext);
 
   const {
     data,

--- a/src/components/pages/StoreDetailPage/StoreDetailPage.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useContext, useState, useRef, useEffect } from "react";
+import { Fragment, useContext, useState } from "react";
 import { useInfiniteQuery, useQuery } from "react-query";
 import { useParams } from "react-router-dom";
 import { ReviewShape } from "types/common";
@@ -30,18 +30,13 @@ import StoreReviewItem from "components/pages/StoreDetailPage/StoreReviewItem/St
 
 function StoreDetailPage() {
   const { storeId: restaurantId } = useParams();
-  const previousRestaurantId = useRef<string | undefined | null>(null);
-
-  useEffect(() => {
-    previousRestaurantId.current = restaurantId;
-  }, [restaurantId]);
 
   const { data: storeData, isFetching: isStoreFetching } = useQuery(
     "storeDetailInfo",
     () => fetchStoreDetail(restaurantId as string),
     {
       retry: NETWORK.RETRY_COUNT,
-      enabled: restaurantId !== previousRestaurantId.current,
+      refetchOnWindowFocus: false,
     }
   );
 
@@ -59,7 +54,7 @@ function StoreDetailPage() {
   } = useInfiniteQuery(
     ["reviewDetailStore", { restaurantId }],
     fetchReviewList,
-    { getNextPageParam }
+    { getNextPageParam, refetchOnWindowFocus: false }
   );
 
   const loadMoreReviews = () => {

--- a/src/components/pages/StoreDetailPage/StoreDetailPage.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailPage.tsx
@@ -24,6 +24,7 @@ import Spinner from "components/common/Spinner/Spinner";
 
 import ReviewInputBottomSheet from "components/pages/StoreDetailPage/ReviewInputBottomSheet/ReviewInputBottomSheet";
 import * as S from "components/pages/StoreDetailPage/StoreDetailPage.style";
+import StoreDetailSkeleton from "components/pages/StoreDetailPage/StoreDetailSkeleton/StoreDetailSkeleton";
 import StoreDetailTitle from "components/pages/StoreDetailPage/StoreDetailTitle/StoreDetailTitle";
 import StoreReviewItem from "components/pages/StoreDetailPage/StoreReviewItem/StoreReviewItem";
 
@@ -32,7 +33,7 @@ function StoreDetailPage() {
   const [isReviewOpen, setIsReviewOpen] = useState(false);
   const isLoggedIn = useContext(LoginContext);
 
-  const { data: storeData } = useQuery(
+  const { data: storeData, isFetching: isStoreFetching } = useQuery(
     "storeDetailInfo",
     () => fetchStoreDetail(restaurantId as string),
     {
@@ -76,6 +77,7 @@ function StoreDetailPage() {
     ) || [];
 
   if (!restaurantId || !storeData) return null;
+  if (isStoreFetching) return <StoreDetailSkeleton />;
   return (
     <S.StoreDetailPageContainer>
       <S.StorePreviewImage

--- a/src/components/pages/StoreDetailPage/StoreDetailSkeleton/StoreDetailSkeleton.tsx
+++ b/src/components/pages/StoreDetailPage/StoreDetailSkeleton/StoreDetailSkeleton.tsx
@@ -1,0 +1,16 @@
+import ImageSkeleton from "components/common/ImageSkeleton/ImageSkeleton";
+
+import * as S from "components/pages/StoreDetailPage/StoreDetailPage.style";
+
+function StoreDetailSkeleton() {
+  return (
+    <S.StoreDetailPageContainer>
+      <ImageSkeleton width="100%" height="30rem" />
+      <S.StoreReviewContentWrapper>
+        <p>가게 정보를 불러오는 중입니다...</p>
+      </S.StoreReviewContentWrapper>
+    </S.StoreDetailPageContainer>
+  );
+}
+
+export default StoreDetailSkeleton;


### PR DESCRIPTION
closes #191 

- [x] 포커스를 벗어났다가 돌아와도 데이터가 다시 패치되지 않도록 한다.
- [x] 데이터를 패치하는 중에는 이전 식당 정보를 표시하는 것이 아닌, 스켈레톤 화면을 표시할 수 있도록 한다.
- [x] 리뷰 영역에 대한 로딩 스피너를 화면 하단으로 이동시켜 식당 상세 정보를 가리지 않도록 한다.

## 최종 화면

| 개선 전 | 개선 후 |
|---------|---------|
| ![개선 전](https://github.com/The-Fellowship-of-the-matzip/mat.zip-front/assets/61104776/51f694fb-6e7c-444b-811a-119f1e77f415) | ![개선 후](https://github.com/The-Fellowship-of-the-matzip/mat.zip-front/assets/61104776/e4904653-3272-41d4-98ca-f63ee6877d2b) |

## 상세 화면
### 데이터 패치 옵션 변경
- 식당 상세 데이터와 식당에 대한 리뷰 데이터는 즉각적인 업데이트가 필요한 데이터가 아니기 때문에 포커스마다 다시 패치될 필요는 없을 것 같다고 판단했습니다. 특히, 현재는 창을 이동할 때마다 로딩 스피너가 노출되고 있습니다. **패치 횟수를 줄임으로써, 불필요한 로딩 스피너를 최소화하고 보다 원활한 사용자 경험을 제공할 수 있을 것이라 판단**했습니다.
- refetchOnWindowFocus 옵션을 `false` 로 변경했습니다.

### 스켈레톤 화면
![스크린샷 2024-06-24 오후 3 49 17](https://github.com/The-Fellowship-of-the-matzip/mat.zip-front/assets/61104776/775094ba-b15f-4fdb-8138-337ac3cf40f2)

### 리뷰 영역 로딩 스피너 이동
![스크린샷 2024-06-24 오후 3 50 21](https://github.com/The-Fellowship-of-the-matzip/mat.zip-front/assets/61104776/d9f41c16-491b-4dbb-ae24-f1693c803f1f)
